### PR TITLE
Enforce ESLint in `npm test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "bin": "./bin/perjury.js",
   "scripts": {
     "lint": "eslint bin/*.js lib/*.js test/*.js",
-    "test": "node test/standalone.js && node bin/perjury.js test/test-*.* && (check-node-version --node '< 7.10.1' --quiet || node bin/perjury.js test/atest-*.js)",
+    "test": "npm run lint && node test/standalone.js && node bin/perjury.js test/test-*.* && (check-node-version --node '< 7.10.1' --quiet || node bin/perjury.js test/atest-*.js)",
     "test-coverage": "nyc -r lcov npm test"
   },
   "directories": {


### PR DESCRIPTION
I find that without a change like this people just forget to lint, check in loads of errors, and the rules become useless. I'd merge right now but there are already errors needing to be fixed.